### PR TITLE
Add support for downloading screen snapshots via the REST API

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OXRS-AC-WT32-ESP-LIB
-version=0.0.1
+version=0.1.0
 author=Austins Creations
 maintainer=Austins Creations
 sentence=WT32-SC01 library for Open eXtensible Rack System firmware
@@ -7,4 +7,4 @@ paragraph=
 category=Signal Input/Output
 url=https://github.com/austinscreations/OXRS-AC-WT32-ESP-LIB
 architectures=ESP32
-depends=ArduinoJson,PubSubClient,MqttLogger,WiFiManager,Adafruit GFX Library,Adafruit_MCP9808,Adafruit_SHT4x,Adafruit_SSD1306,RTClib,BH1750,OXRS-IO-API-ESP32-LIB,OXRS-IO-MQTT-ESP32-LIB,OXRS-AC-I2CSensors-ESP-LIB
+depends=ArduinoJson,PubSubClient,MqttLogger,WiFiManager,lvgl,Adafruit GFX Library,Adafruit_MCP9808,Adafruit_SHT4x,Adafruit_SSD1306,RTClib,BH1750,OXRS-IO-API-ESP32-LIB,OXRS-IO-MQTT-ESP32-LIB,OXRS-AC-I2CSensors-ESP-LIB

--- a/src/OXRS_WT32.cpp
+++ b/src/OXRS_WT32.cpp
@@ -527,7 +527,7 @@ void OXRS_WT32::_initialiseRestApi(void)
   // Register our callbacks
   _api.onAdopt(_apiAdopt);
   
-  _api.get("/snapshot", &_getApiSnapshot);
+  _api.get("/snapshot.bin", &_getApiSnapshot);
 
   // Start listening
   _server.begin();

--- a/src/OXRS_WT32.cpp
+++ b/src/OXRS_WT32.cpp
@@ -197,7 +197,7 @@ void _getApiSnapshot(Request &req, Response &res)
   snapshot = lv_snapshot_take(lv_scr_act(), LV_IMG_CF_TRUE_COLOR_ALPHA);
 
   uint8_t * bufferPtr = (uint8_t *)snapshot->data;
-  size_t bufferSize = SCREEN_WIDTH * SCREEN_HEIGHT * 3;
+  size_t bufferSize = WT32_SCREEN_WIDTH * WT32_SCREEN_HEIGHT * 3;
 
   // Convert to RGB888
   lv_color_t color;

--- a/src/OXRS_WT32.cpp
+++ b/src/OXRS_WT32.cpp
@@ -8,10 +8,13 @@
 #include <Ethernet.h>     // For networking
 #include <WiFi.h>         // Required for Ethernet to get MAC
 #include <MqttLogger.h>   // For logging
-#include <lvgl.h>         // For graphics
 
 #if defined(WIFI_MODE)
 #include <WiFiManager.h>  // For WiFi AP config
+#endif
+
+#if defined(LV_USE_SNAPSHOT)
+#include <lvgl.h>         // For graphic snapshots
 #endif
 
 // Macro for converting env vars to strings
@@ -51,9 +54,6 @@ DynamicJsonDocument _fwCommandSchema(2048);
 // MQTT callbacks wrapped by _mqttConfig/_mqttCommand
 jsonCallback _onConfig;
 jsonCallback _onCommand;
-
-// Snapshot API
-lv_img_dsc_t *snapshot = NULL;
 
 /* JSON helpers */
 void _mergeJson(JsonVariant dst, JsonVariantConst src)
@@ -185,6 +185,10 @@ void _apiAdopt(JsonVariant json)
   _getCommandSchemaJson(json);
 }
 
+#if defined(LV_USE_SNAPSHOT)
+// Snapshot API
+lv_img_dsc_t *snapshot = NULL;
+
 void _getApiSnapshot(Request &req, Response &res)
 {
   // Clear any previous snapshot from memory
@@ -213,6 +217,7 @@ void _getApiSnapshot(Request &req, Response &res)
   res.set("Content-Type", "application/octet-stream");
   res.write(bufferPtr, bufferSize);
 }
+#endif
 
 /* MQTT callbacks */
 void _mqttConnected()
@@ -547,8 +552,10 @@ void OXRS_WT32::_initialiseRestApi(void)
   // Register our callbacks
   _api.onAdopt(_apiAdopt);
   
+#if defined(LV_USE_SNAPSHOT)
   // Custom endpoint for downloading a snapshot of the WT32 display
   _api.get("/snapshot.bin", &_getApiSnapshot);
+#endif
 
   // Start listening
   _server.begin();

--- a/src/OXRS_WT32.cpp
+++ b/src/OXRS_WT32.cpp
@@ -188,6 +188,7 @@ void _getApiSnapshot(Request &req, Response &res)
   uint8_t *bufferPtr;
   size_t bufferSize;
   
+  // External function which needs to be implemented by the upstream firmware
   makeSnapShot(&bufferPtr, &bufferSize);
   
   res.set("Content-Type", "application/octet-stream");
@@ -527,6 +528,7 @@ void OXRS_WT32::_initialiseRestApi(void)
   // Register our callbacks
   _api.onAdopt(_apiAdopt);
   
+  // Custom endpoint for downloading a snapshot of the WT32 display
   _api.get("/snapshot.bin", &_getApiSnapshot);
 
   // Start listening

--- a/src/OXRS_WT32.cpp
+++ b/src/OXRS_WT32.cpp
@@ -51,6 +51,8 @@ DynamicJsonDocument _fwCommandSchema(2048);
 jsonCallback _onConfig;
 jsonCallback _onCommand;
 
+extern void makeSnapShot(uint8_t **bufferPtr, size_t *bufferSize);
+
 /* JSON helpers */
 void _mergeJson(JsonVariant dst, JsonVariantConst src)
 {
@@ -179,6 +181,17 @@ void _apiAdopt(JsonVariant json)
   _getNetworkJson(json);
   _getConfigSchemaJson(json);
   _getCommandSchemaJson(json);
+}
+
+void _getApiSnapshot(Request &req, Response &res)
+{
+  uint8_t *bufferPtr;
+  size_t bufferSize;
+  
+  makeSnapShot(&bufferPtr, &bufferSize);
+  
+  res.set("Content-Type", "application/octet-stream");
+  res.write(bufferPtr, bufferSize);
 }
 
 /* MQTT callbacks */
@@ -513,6 +526,8 @@ void OXRS_WT32::_initialiseRestApi(void)
   
   // Register our callbacks
   _api.onAdopt(_apiAdopt);
+  
+  _api.get("/snapshot", &_getApiSnapshot);
 
   // Start listening
   _server.begin();

--- a/src/OXRS_WT32.h
+++ b/src/OXRS_WT32.h
@@ -19,6 +19,10 @@
 // REST API
 #define REST_API_PORT             80
 
+// Screen dimensions
+#define SCREEN_WIDTH              320
+#define SCREEN_HEIGHT             480
+
 // Enum for the different connection states
 enum connectionState_t { CONNECTED_NONE, CONNECTED_IP, CONNECTED_MQTT };
 

--- a/src/OXRS_WT32.h
+++ b/src/OXRS_WT32.h
@@ -20,8 +20,8 @@
 #define REST_API_PORT             80
 
 // Screen dimensions
-#define SCREEN_WIDTH              320
-#define SCREEN_HEIGHT             480
+#define WT32_SCREEN_WIDTH         320
+#define WT32_SCREEN_HEIGHT        480
 
 // Enum for the different connection states
 enum connectionState_t { CONNECTED_NONE, CONNECTED_IP, CONNECTED_MQTT };


### PR DESCRIPTION
@moinmoin-sh can you have a look at this?

Have moved the snapshot code into the WT32 library so it would be available to any firmware based on it. Means the TP32 firmware doesn't even have to worry about this feature, but also means the WT32 library is now dependent on LVGL.
 It is only enabled if `LV_USE_SNAPSHOT` is set.


